### PR TITLE
Bump version to latest OpenCV release, add build support for Python 3

### DIFF
--- a/buildOpenCV.sh
+++ b/buildOpenCV.sh
@@ -18,12 +18,15 @@ sudo apt-get install -y \
     libtbb-dev \
     libgtk2.0-dev \
     cmake \
-    pkg-config
+    pkg-config \
+    libatlas-base-dev \
+    gfortran \
+    libgtk-3-dev
 
 # Python 2.7
 sudo apt-get install -y python-dev python-numpy python-py python-pytest
 
-# Python 3.0
+# Python 3
 sudo apt-get install -y python3-dev python3-numpy python3-py python3-pytest
 
 # GStreamer support

--- a/buildOpenCV.sh
+++ b/buildOpenCV.sh
@@ -22,18 +22,22 @@ sudo apt-get install -y \
 
 # Python 2.7
 sudo apt-get install -y python-dev python-numpy python-py python-pytest
+
+# Python 3.0
+sudo apt-get install -y python3-dev python3-numpy python3-py python3-pytest
+
 # GStreamer support
 sudo apt-get install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev 
 
 
 git clone https://github.com/opencv/opencv.git
 cd opencv
-git checkout -b v3.3.0 3.3.0
+git checkout -b v3.3.1 3.3.1
 # This is for the test data
 cd $HOME
 git clone https://github.com/opencv/opencv_extra.git
 cd opencv_extra
-git checkout -b v3.3.0 3.3.0
+git checkout -b v3.3.1 3.3.1
 
 cd $HOME/opencv
 mkdir build
@@ -51,7 +55,7 @@ cmake \
     -DBUILD_EXAMPLES=ON \
     -DBUILD_opencv_java=OFF \
     -DBUILD_opencv_python2=ON \
-    -DBUILD_opencv_python3=OFF \
+    -DBUILD_opencv_python3=ON \
     -DENABLE_PRECOMPILED_HEADERS=OFF \
     -DWITH_OPENCL=OFF \
     -DWITH_OPENMP=OFF \


### PR DESCRIPTION
Hello!

Thanks for your script! I've added Python 3 support and bumped the OpenCV version to the latest release for the TX1. I've run this locally, and tested installation in both the Python 2 and 3 environment. All seems to work well!

Not sure about the added libgtk-3-dev, libatlas-base-dev, and gfortran additions, but another post said these were required. 

Thanks!